### PR TITLE
Migration to .NET 10 and PostgreSQL

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,7 @@
 using ordermanager_dotnet.Data;
 using Microsoft.EntityFrameworkCore;
 using System.Text.Json.Serialization;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using System.Text;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using ordermanager_dotnet.Helpers;
@@ -10,10 +10,9 @@ using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
 string connectionString = builder.Configuration.GetConnectionString("Default");
-builder.Services.AddDbContext<DataContext>(options => options.UseMySql(connectionString,
-ServerVersion.AutoDetect(connectionString)));
+
+builder.Services.AddDbContext<DataContext>(options => options.UseNpgsql(connectionString));
 
 builder.Services.AddControllers().AddJsonOptions(x =>
   x.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles);

--- a/appsettings.json
+++ b/appsettings.json
@@ -3,7 +3,7 @@
     "Secret": "THIS IS USED TO SIGN AND VERIFY JWT TOKENS, REPLACE IT WITH YOUR OWN SECRET, IT CAN BE ANY STRING"
   },
   "ConnectionStrings": {
-    "Default": "Server=localhost;Port=3306;Uid=root;Password=admin12345;Database=ordermanagerdb;SslMode=none;AllowPublicKeyRetrieval=True"
+    "Default": "Host=localhost;Port=5432;Database=ordermanagerdb;Username=postgres;Password=admin12345"
   },
   "Logging": {
     "LogLevel": {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-    "sdk": {
-        "version": "9.0.311",
-        "rollForward": "latestFeature"
-    }
-}

--- a/ordermanager-dotnet.csproj
+++ b/ordermanager-dotnet.csproj
@@ -1,17 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>ordermanager_dotnet</RootNamespace>
+    <!-- Bypass the package pruning data error -->
+    <AllowMissingPrunePackageData>true</AllowMissingPrunePackageData>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.13"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.13"/>
-    <PackageReference Include="AutoMapper" Version="16.1.1"/>
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.13"/>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0"/>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="AutoMapper" Version="16.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Migration to .NET 10.
Pomelo does not support .NET 10.
I migrated to PostgreSQL using Npgsql with EF integration.

## .NET 8 and .NET 9 End of Support

Microsoft has announced that both .NET 8 and .NET 9 will reach End of Support on November 10, 2026. After this date, these versions will no longer receive security updates, bug fixes, or technical support.

- .NET 8 (LTS)
  
  - Release date: November 14, 2023
  - End of Support: November 10, 2026

- .NET 9 (STS)
  
  - Release date: November 12, 2024
  - End of Support: November 10, 2026

To remain in a supported environment, Microsoft recommends upgrading to .NET 10 (LTS), released on November 11, 2025, which will receive support until November 14, 2028. Migrating ensures continued security updates, bug fixes, performance improvements, and access to the latest features of the .NET platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Updated the application to use PostgreSQL for database connectivity.
  * Upgraded the application runtime and supporting platform components.
  * Improved project configuration to support current development and deployment environments.

* **Compatibility**
  * Replaced MySQL-specific database integration with PostgreSQL support.
  * Updated database connection settings for the new PostgreSQL environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->